### PR TITLE
add yarn install to deploy-to-gcp workflow

### DIFF
--- a/.github/workflows/deploy-to-gcp.yml
+++ b/.github/workflows/deploy-to-gcp.yml
@@ -23,6 +23,10 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
       
+      - name: Install dependencies
+        working_directory: ./frontend
+        run: yarn install
+      
       - name: Install SSH key
         uses: shimataro/ssh-key-action@v2
         with:


### PR DESCRIPTION
ensure we install dependencies before we build docker image